### PR TITLE
Add table metrics

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -93,5 +93,5 @@ func (a *app) run(cliCtx *cli.Context) error {
 	}()
 
 	// start the regular collecting routine
-	return col.Start(ctx, a.cfg.CollectInterval)
+	return col.Start(ctx, a.cfg.CollectInterval, a.cfg.Database)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  firebolt-otel-exporter:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    container_name: firebolt-otel-exporter
+    environment:
+      - FIREBOLT_OTEL_EXPORTER_CLIENT_ID=
+      - FIREBOLT_OTEL_EXPORTER_CLIENT_SECRET=
+      - FIREBOLT_OTEL_EXPORTER_ACCOUNTS=eu-west-1
+      - FIREBOLT_OTEL_EXPORTER_GRPC_ADDRESS=127.0.0.1:4317
+      - FIREBOLT_OTEL_EXPORTER_LOG_LEVEL=debug
+      - FIREBOLT_OTEL_EXPORTER_DATABASE=
+    network_mode: host
+  otel-collector:
+    image: grafana/otel-lgtm
+    ports:
+      - 4317:4317 # OTLP http receiver
+      - 4318:4318 # OTLP http receiver
+      - 3000:3000 # grafana port

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -16,7 +16,7 @@ type Collector interface {
 	// Close should be called to clean up allocated resources
 	Close(ctx context.Context) error
 	// Start is a blocking function which should run the main collector's process
-	Start(ctx context.Context, interval time.Duration) error
+	Start(ctx context.Context, interval time.Duration, database string) error
 }
 
 // collector is an implementation of Collector interface.
@@ -29,6 +29,7 @@ type collector struct {
 
 	runtimeMetrics      *runtimeMetrics
 	queryHistoryMetrics *queryHistoryMetrics
+	tableHistoryMetrics *tableHistoryMetrics
 	exporterMetrics     *exporterMetrics
 
 	lastCollectedTime time.Time
@@ -83,6 +84,10 @@ func (c *collector) setupMetrics() error {
 	}
 
 	if err := c.setupQueryHistoryMetrics(); err != nil {
+		return err
+	}
+
+	if err := c.setupTableHistoryMetrics(); err != nil {
 		return err
 	}
 

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -59,6 +59,7 @@ type fetcherMock struct {
 	fetchEnginesFn            func(ctx context.Context, accountName string) ([]fetcher.Engine, error)
 	fetchRuntimePointsFn      func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.EngineRuntimePoint
 	fetchQueryHistoryPointsFn func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.QueryHistoryPoint
+	fetchTableHistoryPointsFn func(ctx context.Context, account string, engines []fetcher.Engine, database string) <-chan fetcher.TableHistoryPoint
 }
 
 func newFetcherMock() *fetcherMock {
@@ -72,6 +73,9 @@ func newFetcherMock() *fetcherMock {
 		fetchQueryHistoryPointsFn: func(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.QueryHistoryPoint {
 			panic("default FetchQueryHistoryPoints")
 		},
+		fetchTableHistoryPointsFn: func(ctx context.Context, account string, engines []fetcher.Engine, database string) <-chan fetcher.TableHistoryPoint {
+			panic("default FetchTableHistoryPoints")
+		},
 	}
 }
 
@@ -83,6 +87,10 @@ func (m *fetcherMock) FetchRuntimePoints(ctx context.Context, account string, en
 }
 func (m *fetcherMock) FetchQueryHistoryPoints(ctx context.Context, account string, engines []fetcher.Engine, since, till time.Time) <-chan fetcher.QueryHistoryPoint {
 	return m.fetchQueryHistoryPointsFn(ctx, account, engines, since, till)
+}
+
+func (m *fetcherMock) FetchTableHistoryPoints(ctx context.Context, account string, engines []fetcher.Engine, database string) <-chan fetcher.TableHistoryPoint {
+	return m.fetchTableHistoryPointsFn(ctx, account, engines, database)
 }
 
 type exporterMock struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,9 @@ type Config struct {
 	// CollectInterval specifies how often otel-exporter will collect metrics from Firebolt. It will also define
 	// a discretion step of reported metrics.
 	CollectInterval time.Duration `env:"FIREBOLT_OTEL_EXPORTER_COLLECT_INTERVAL,default=30s"`
+
+	// Database for which table metrics will be fetched
+	Database string `env:"FIREBOLT_OTEL_EXPORTER_DATABASE"`
 }
 
 // Validate validates Config
@@ -43,6 +46,7 @@ func (c Config) Validate() error {
 		validation.Field(&c.Exporter),
 		// Minimal allowed collect interval is 15s.
 		validation.Field(&c.CollectInterval, validation.Required, validation.Min(15*time.Second)),
+		validation.Field(&c.Database, validation.Required),
 	)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,6 +22,7 @@ func Test_Config(t *testing.T) {
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_CLIENT_ID", "client_id")
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_CLIENT_SECRET", "client_secret")
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_GRPC_ADDRESS", "grpc_address")
+	os.Setenv("FIREBOLT_OTEL_EXPORTER_DATABASE", "test_db")
 
 	cfg, err := config.NewConfig(context.Background())
 	require.NoError(t, err)
@@ -42,6 +43,7 @@ func Test_Config(t *testing.T) {
 			},
 		},
 		CollectInterval: 30 * time.Second,
+		Database:        "test_db",
 	}, cfg)
 }
 
@@ -50,6 +52,7 @@ func Test_Config_MissingCreds(t *testing.T) {
 
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_ACCOUNTS", "acc1,acc2")
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_GRPC_ADDRESS", "grpc_address")
+	os.Setenv("FIREBOLT_OTEL_EXPORTER_DATABASE", "test_db")
 
 	cfg, err := config.NewConfig(context.Background())
 	require.Error(t, err)
@@ -67,6 +70,7 @@ func Test_Config_OverrideDefaults(t *testing.T) {
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_CLIENT_ID", "client_id")
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_CLIENT_SECRET", "client_secret")
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_GRPC_ADDRESS", "grpc_address")
+	os.Setenv("FIREBOLT_OTEL_EXPORTER_DATABASE", "test_db")
 
 	cfg, err := config.NewConfig(context.Background())
 	require.NoError(t, err)
@@ -87,6 +91,7 @@ func Test_Config_OverrideDefaults(t *testing.T) {
 			},
 		},
 		CollectInterval: 60 * time.Second,
+		Database:        "test_db",
 	}, cfg)
 }
 
@@ -102,6 +107,7 @@ func Test_Config_GRPC(t *testing.T) {
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_GRPC_OAUTH_CLIENT_SECRET", "oauth_client_secret")
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_GRPC_OAUTH_TOKEN_URL", "oauth_token_url")
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_SYSTEM_CERT_POOL", "true")
+	os.Setenv("FIREBOLT_OTEL_EXPORTER_DATABASE", "test_db")
 
 	cfg, err := config.NewConfig(context.Background())
 	require.NoError(t, err)
@@ -136,6 +142,7 @@ func Test_Config_GRPC(t *testing.T) {
 			},
 		},
 		CollectInterval: 30 * time.Second,
+		Database:        "test_db",
 	}, cfg)
 }
 
@@ -150,6 +157,7 @@ func Test_Config_HTTP(t *testing.T) {
 
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_HTTP_TLS_X509_CERT_PEM_BLOCK", "cert_pem_block")
 	os.Setenv("FIREBOLT_OTEL_EXPORTER_HTTP_TLS_X509_KEY_PEM_BLOCK", "key_pem_block")
+	os.Setenv("FIREBOLT_OTEL_EXPORTER_DATABASE", "test_db")
 
 	cfg, err := config.NewConfig(context.Background())
 	require.NoError(t, err)
@@ -176,5 +184,6 @@ func Test_Config_HTTP(t *testing.T) {
 			},
 		},
 		CollectInterval: 30 * time.Second,
+		Database:        "test_db",
 	}, cfg)
 }

--- a/internal/fetcher/model.go
+++ b/internal/fetcher/model.go
@@ -62,3 +62,14 @@ type QueryHistoryPoint struct {
 	ReturnedBytes           sql.NullInt64
 	TimeInQueueMicroSeconds sql.NullInt64
 }
+
+type TableHistoryPoint struct {
+	TableName string
+
+	NumberOfRows      sql.NullInt64
+	CompressedBytes   sql.NullInt64
+	UncompressedBytes sql.NullInt64
+	CompressionRatio  sql.NullFloat64
+	NumberOfTablets   sql.NullInt64
+	Fragmentation     sql.NullFloat64
+}


### PR DESCRIPTION
Adds table metrics reporting by extending the tool to take in a specific database name, and scrape metrics for all base tables in that database. 

Also adds a docker compose stack for local testing.